### PR TITLE
Add function to generate code span syntax

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,48 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python Build
+
+on: [pull_request]
+
+jobs:
+  flake8:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install --dev
+    - name: Setup flake8 annotations
+      uses: rbialon/flake8-annotations@v1
+    - name: Lint with flake8
+      run: |
+        # The GitHub editor is 127 chars wide
+        pipenv run flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+
+  pytest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install --dev
+    - name: Test with pytest
+      run: |
+        pipenv run pytest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # github-markdown-ui
 GitHub flavored markdown utilities
+
+
+# Legal
+&copy; LinkedIn 2020, All Rights Reserved

--- a/githubmarkdownui/inline.py
+++ b/githubmarkdownui/inline.py
@@ -1,7 +1,6 @@
 def code_span(text: str, delimiter: int = 1) -> str:
-    """Returns the text surrounded by backtick (`) characters. If the text
-    contains one or more backtick characters, then the delimiter must be set
-    to a value that is greater than the number of consecutive backticks.
+    """Returns the text surrounded by backtick (`) characters. If the text contains one or more backtick characters, then the delimiter must be set to a value
+    that is greater than the number of consecutive backticks.
 
     :raises: Exception if the delimiter is less than 1
     """

--- a/githubmarkdownui/inline.py
+++ b/githubmarkdownui/inline.py
@@ -1,0 +1,11 @@
+def code_span(string: str, delimiter: int = 1) -> str:
+    """Returns a string surrounded by backtick (`) characters. If your string
+    contains one or more backtick characters, then the delimiter must be set
+    to a value that is greater than the number of consecutive backticks.
+
+    :raises: Exception if the delimiter is less than 1
+    """
+    if delimiter < 1:
+        raise Exception('The delimiter must be 1 or more')
+
+    return '`' * delimiter + string + '`' * delimiter

--- a/githubmarkdownui/inline.py
+++ b/githubmarkdownui/inline.py
@@ -1,6 +1,6 @@
 def code_span(text: str, delimiter: int = 1) -> str:
-    """Returns the text surrounded by backtick (`) characters. If the text contains one or more backtick characters, then the delimiter must be set to a value
-    that is greater than the number of consecutive backticks.
+    """Returns the text surrounded by backtick (`) characters. If the text contains one or more backtick characters, then the
+    delimiter must be set to a value that is greater than the number of consecutive backticks.
 
     :raises: Exception if the delimiter is less than 1
     """

--- a/githubmarkdownui/inline.py
+++ b/githubmarkdownui/inline.py
@@ -1,5 +1,5 @@
-def code_span(string: str, delimiter: int = 1) -> str:
-    """Returns a string surrounded by backtick (`) characters. If your string
+def code_span(text: str, delimiter: int = 1) -> str:
+    """Returns the text surrounded by backtick (`) characters. If the text
     contains one or more backtick characters, then the delimiter must be set
     to a value that is greater than the number of consecutive backticks.
 
@@ -8,4 +8,4 @@ def code_span(string: str, delimiter: int = 1) -> str:
     if delimiter < 1:
         raise Exception('The delimiter must be 1 or more')
 
-    return '`' * delimiter + string + '`' * delimiter
+    return '`' * delimiter + text + '`' * delimiter

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 160

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 160
+max-line-length = 127

--- a/test/test_inline.py
+++ b/test/test_inline.py
@@ -1,0 +1,17 @@
+import pytest
+
+import githubmarkdownui.inline as inline
+
+
+@pytest.mark.parametrize('string, delimiter', [
+    ('hello world', 1),
+    ('hello ` world', 2),
+    ('hello world', 0),
+])
+def test_code_span(string, delimiter):
+    if delimiter == 0:
+        with pytest.raises(Exception):
+            inline.code_span(string, delimiter=delimiter)
+    else:
+        assert (inline.code_span(string, delimiter=delimiter) ==
+                '`' * delimiter + string + '`' * delimiter)

--- a/test/test_inline.py
+++ b/test/test_inline.py
@@ -13,5 +13,4 @@ def test_code_span(string, delimiter):
         with pytest.raises(Exception):
             inline.code_span(string, delimiter=delimiter)
     else:
-        assert (inline.code_span(string, delimiter=delimiter) ==
-                '`' * delimiter + string + '`' * delimiter)
+        assert inline.code_span(string, delimiter=delimiter) == '`' * delimiter + string + '`' * delimiter


### PR DESCRIPTION
This function is placed in a file called inline because the [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) categorizes code spans as an inline.

Code spans look like the following: `abc` or ``abc`def``