### PR TITLE
Implement block structures, check description, and strikethrough

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
     "python.linting.pylintEnabled": false,
     "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
+    "python.linting.enabled": true,
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/githubmarkdownui/blocks/leaf.py
+++ b/githubmarkdownui/blocks/leaf.py
@@ -5,7 +5,7 @@ from githubmarkdownui.constants import HEADING_MAX_LEVEL, HEADING_MIN_LEVEL
 
 def thematic_break() -> str:
     """Returns a <hr> tag, used to create a thematic break. Equivalent to --- in Markdown."""
-    pass
+    return '<hr>'
 
 
 def code_block(text: str, language: Optional[str] = None) -> str:
@@ -15,7 +15,10 @@ def code_block(text: str, language: Optional[str] = None) -> str:
     :param text: The text inside the code block
     :param language: The language to use for syntax highlighting
     """
-    pass
+    if language:
+        return f'```{language}\n{text}\n```'
+
+    return f'<pre><code>{text}</code></pre>'
 
 
 def heading(text: str, level: int) -> str:

--- a/githubmarkdownui/blocks/lists.py
+++ b/githubmarkdownui/blocks/lists.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Union
+from typing import Optional, List, Union
 
 
 @dataclass
@@ -67,7 +67,7 @@ class UnorderedList(HtmlList):
         return f'<ul>{self.build_list_contents()}</ul>'
 
 
-def task_list(items: List[str], items_to_check: List[int]) -> str:
+def task_list(items: List[str], items_to_check: Optional[List[int]] = None) -> str:
     """Creates a task list in GitHub Flavored Markdown where each item can be checked off. This task list cannot be used
     inside a table.
 
@@ -76,4 +76,16 @@ def task_list(items: List[str], items_to_check: List[int]) -> str:
 
     :raises: Exception if an index in items_to_check does not exist in the items list
     """
-    pass
+    if not items_to_check:
+        items_to_check = []
+
+    for index in items_to_check:
+        if index < 0 or index > len(items) - 1:
+            raise Exception(f'Cannot check off non-existent index {index} in task list')
+
+    task_list_syntax = ''
+
+    for i in range(len(items)):
+        task_list_syntax += f'- [{"x" if i in items_to_check else " "}] {items[i]}\n'
+
+    return task_list_syntax.rstrip('\n')

--- a/githubmarkdownui/blocks/lists.py
+++ b/githubmarkdownui/blocks/lists.py
@@ -85,7 +85,7 @@ def task_list(items: List[str], items_to_check: Optional[List[int]] = None) -> s
 
     task_list_syntax = ''
 
-    for i in range(len(items)):
-        task_list_syntax += f'- [{"x" if i in items_to_check else " "}] {items[i]}\n'
+    for index, item in enumerate(items):
+        task_list_syntax += f'- [{"x" if index in items_to_check else " "}] {item}\n'
 
     return task_list_syntax.rstrip('\n')

--- a/githubmarkdownui/blocks/table.py
+++ b/githubmarkdownui/blocks/table.py
@@ -39,8 +39,7 @@ def table(content: List[List[str]], alignment: List[Optional[TableAlignment]] = 
     """
     # Check if the inputs are valid. The content parameter must be a m x n matrix and alignment must be the same length as
     # one element in content.
-    is_valid_table = all(isinstance(row, list) and len(row) == len(content[0]) for row in content)
-    if not is_valid_table:
+    if not all(isinstance(row, list) and len(row) == len(content[0]) for row in content):
         raise TableDimensionError('Each row in the table must have the same number of columns')
 
     if alignment and len(alignment) != len(content[0]):
@@ -49,27 +48,27 @@ def table(content: List[List[str]], alignment: List[Optional[TableAlignment]] = 
     table_syntax = '<table><thead><tr>'
 
     # Build the table header.
-    for i in range(len(content[0])):
-        if alignment and alignment[i]:
-            table_syntax += f'<th align="{alignment[i].value}">'
+    for index, item in enumerate(content[0]):
+        if alignment and alignment[index]:
+            table_syntax += f'<th align="{alignment[index].value}">'
         else:
             table_syntax += '<th>'
 
-        table_syntax += f'{content[0][i]}</th>'
+        table_syntax += f'{item}</th>'
 
     table_syntax += '</tr></thead><tbody>'
 
-    # Build the table body.
-    for i in range(1, len(content)):
+    # Build the table body. Skip the first list in content because that is the table headers.
+    for row in content[1:]:
         table_syntax += '<tr>'
 
-        for j in range(len(content[i])):
-            if alignment and alignment[j]:
-                table_syntax += f'<td align="{alignment[j].value}">'
+        for index, item in enumerate(row):
+            if alignment and alignment[index]:
+                table_syntax += f'<td align="{alignment[index].value}">'
             else:
                 table_syntax += '<td>'
 
-            table_syntax += f'{content[i][j]}</td>'
+            table_syntax += f'{item}</td>'
 
         table_syntax += '</tr>'
 

--- a/githubmarkdownui/blocks/table.py
+++ b/githubmarkdownui/blocks/table.py
@@ -1,4 +1,4 @@
-from enum import Enum, auto
+from enum import Enum
 from typing import List, Optional
 
 
@@ -11,9 +11,9 @@ class TableDimensionError(Exception):
 
 
 class TableAlignment(Enum):
-    CENTER = auto()
-    LEFT = auto()
-    RIGHT = auto()
+    CENTER = 'center'
+    LEFT = 'left'
+    RIGHT = 'right'
 
 
 def table(content: List[List[str]], alignment: List[Optional[TableAlignment]] = None) -> str:
@@ -37,4 +37,42 @@ def table(content: List[List[str]], alignment: List[Optional[TableAlignment]] = 
     :raises: TableAlignmentError when the alignment parameter is not the same length as the sublists of content
     :raises: TableDimensionError when the sublists of content do not contain the same number of elements
     """
-    pass
+    # Check if the inputs are valid. The content parameter must be a m x n matrix and alignment must be the same length as
+    # one element in content.
+    is_valid_table = all(isinstance(row, list) and len(row) == len(content[0]) for row in content)
+    if not is_valid_table:
+        raise TableDimensionError('Each row in the table must have the same number of columns')
+
+    if alignment and len(alignment) != len(content[0]):
+        raise TableAlignmentError('The alignment parameter is not the same length as a row in the table')
+
+    table_syntax = '<table><thead><tr>'
+
+    # Build the table header.
+    for i in range(len(content[0])):
+        if alignment and alignment[i]:
+            table_syntax += f'<th align="{alignment[i].value}">'
+        else:
+            table_syntax += '<th>'
+
+        table_syntax += f'{content[0][i]}</th>'
+
+    table_syntax += '</tr></thead><tbody>'
+
+    # Build the table body.
+    for i in range(1, len(content)):
+        table_syntax += '<tr>'
+
+        for j in range(len(content[i])):
+            if alignment and alignment[j]:
+                table_syntax += f'<td align="{alignment[j].value}">'
+            else:
+                table_syntax += '<td>'
+
+            table_syntax += f'{content[i][j]}</td>'
+
+        table_syntax += '</tr>'
+
+    table_syntax += '</tbody></table>'
+
+    return table_syntax

--- a/githubmarkdownui/emoji.py
+++ b/githubmarkdownui/emoji.py
@@ -2,12 +2,14 @@ from enum import Enum
 
 
 class Emoji(Enum):
-    X = ':x:'
-    WARNING = ':warning:'
-    CHECK_MARK = ':white_check_mark:'
-    SQUARE = ':white_large_square:'
-    HOURGLASS = ':hourglass_flowing_sand:'
-    INFORMATION = ':information_source:'
-    PAGE = ':page_facing_up:'
-    LOCK = ':lock:'
-    KEY = ':key:'
+    # Use the actual emojis here instead of the shortcuts like :x: or :warning: because that text will show up inside
+    # code blocks instead of the actual emoji.
+    X = '❌'
+    WARNING = '⚠️'
+    CHECK_MARK = '✅'
+    SQUARE = '⬜'
+    HOURGLASS = '⏳'
+    INFORMATION = 'ℹ️'
+    PAGE = '📄'
+    LOCK = '🔒'
+    KEY = '🔑'

--- a/githubmarkdownui/inline.py
+++ b/githubmarkdownui/inline.py
@@ -39,17 +39,17 @@ def link(text: str, url: str) -> str:
     return f'<a href="{url}">{text}</a>'
 
 
+def strikethrough(text: str) -> str:
+    """Formats the text with a strikethrough by placing <del> tags around it.
+
+    :param text: The text to appear with a strikethrough
+    """
+    return f'<del>{text}</del>'
+
+
 def strong_emphasis(text: str) -> str:
     """Strongly emphasizes (bolds) the given text by placing <strong> tags around it.
 
     :param text: The text to be strongly emphasized
     """
     return f'<strong>{text}</strong>'
-
-
-def strikethrough(text: str) -> str:
-    """Formats the text with a strikethrough by placing <del> tags around it.
-
-    :param text: The text to appear with a strikethrough
-    """
-    pass

--- a/githubmarkdownui/utils.py
+++ b/githubmarkdownui/utils.py
@@ -12,4 +12,4 @@ def collapsible_section(title: str, text: str) -> str:
     :param title: The title for this collapsible section
     :param text: The text to be displayed inside this collapsible section
     """
-    pass
+    return f'<details><summary>{title}</summary>\n{text}</details>'

--- a/test/blocks/test_leaf.py
+++ b/test/blocks/test_leaf.py
@@ -4,6 +4,22 @@ from githubmarkdownui.blocks import leaf
 from githubmarkdownui.constants import HEADING_MAX_LEVEL, HEADING_MIN_LEVEL
 
 
+def test_thematic_break():
+    assert leaf.thematic_break() == '<hr>'
+
+
+@pytest.mark.parametrize('language', ['python', None])
+def test_code_block(language):
+    test_code = 'x = 5\nprint("hello world")'
+
+    result = leaf.code_block(test_code, language)
+
+    if language:
+        assert result == '```python\nx = 5\nprint("hello world")\n```'
+    else:
+        assert result == '<pre><code>x = 5\nprint("hello world")</code></pre>'
+
+
 @pytest.mark.parametrize('level', [HEADING_MIN_LEVEL, HEADING_MAX_LEVEL, 0, 7])
 def test_heading(level):
     if level < HEADING_MIN_LEVEL or level > HEADING_MAX_LEVEL:

--- a/test/blocks/test_lists.py
+++ b/test/blocks/test_lists.py
@@ -61,3 +61,17 @@ def test_nested_lists(outer_list_tags, inner_list_tags):
         {outer_list_tags[1]}
         """
     )
+
+
+def test_task_list():
+    assert lists.task_list(['foo', 'bar', 'baz']) == '- [ ] foo\n- [ ] bar\n- [ ] baz'
+
+
+def test_task_list_check_items():
+    assert lists.task_list(['foo', 'bar', 'baz'], [0, 1]) == '- [x] foo\n- [x] bar\n- [ ] baz'
+
+
+@pytest.mark.parametrize('index', [-1, 3, 8])
+def test_task_list_check_invalid_index(index):
+    with pytest.raises(Exception):
+        lists.task_list(['foo', 'bar', 'baz'], [index])

--- a/test/blocks/test_table.py
+++ b/test/blocks/test_table.py
@@ -1,0 +1,83 @@
+import pytest
+
+from githubmarkdownui.blocks import table
+
+from test.helpers import remove_whitespace
+
+
+def test_table():
+    assert table.table([['col1', 'col2'], ['hello', 'world'], ['foo', 'bar']]) == remove_whitespace(
+        """
+        <table>
+            <thead>
+                <tr>
+                    <th>col1</th>
+                    <th>col2</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>hello</td>
+                    <td>world</td>
+                </tr>
+                <tr>
+                    <td>foo</td>
+                    <td>bar</td>
+                </tr>
+            </tbody>
+        </table>
+        """
+    )
+
+
+@pytest.mark.parametrize('alignment', [table.TableAlignment.CENTER, table.TableAlignment.LEFT, table.TableAlignment.RIGHT])
+def test_table_with_alignment(alignment):
+    assert table.table([['col1', 'col2'], ['hello', 'world']], [alignment, alignment]) == remove_whitespace(
+        f"""
+        <table>
+            <thead>
+                <tr>
+                    <th align="{alignment.value}">col1</th>
+                    <th align="{alignment.value}">col2</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td align="{alignment.value}">hello</td>
+                    <td align="{alignment.value}">world</td>
+                </tr>
+            </tbody>
+        </table>
+        """
+    )
+
+
+def test_table_with_only_one_aligned_column():
+    assert table.table([['col1', 'col2'], ['hello', 'world']], [table.TableAlignment.CENTER, None]) == remove_whitespace(
+        """
+        <table>
+            <thead>
+                <tr>
+                    <th align="center">col1</th>
+                    <th>col2</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td align="center">hello</td>
+                    <td>world</td>
+                </tr>
+            </tbody>
+        </table>
+        """
+    )
+
+
+def test_table_alignment_error():
+    with pytest.raises(table.TableAlignmentError):
+        table.table([['col1', 'col2'], ['hello', 'world']], [table.TableAlignment.CENTER])
+
+
+def test_table_dimension_error():
+    with pytest.raises(table.TableDimensionError):
+        table.table([['col1', 'col2'], ['hello']])

--- a/test/test_inline.py
+++ b/test/test_inline.py
@@ -21,5 +21,9 @@ def test_link():
     assert inline.link('LinkedIn', 'https://www.linkedin.com/') == '<a href="https://www.linkedin.com/">LinkedIn</a>'
 
 
+def test_strikethrough():
+    assert inline.strikethrough('hello world') == '<del>hello world</del>'
+
+
 def test_strong_emphasis():
     assert inline.strong_emphasis('hello world') == '<strong>hello world</strong>'

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,10 @@
+from githubmarkdownui import utils
+
+
+def test_check_description():
+    assert utils.check_description('hello world') == '<details><summary>What is this check?</summary>\nhello world</details>'
+
+
+def test_collapsible_section():
+    assert (utils.collapsible_section('my title', 'hello world') ==
+            '<details><summary>my title</summary>\nhello world</details>')


### PR DESCRIPTION
This PR implements remaining block structures, the check description helper to make the a collapsible description section, and strikethroughs.

Each function was tested by taking the output and putting it into a GitHub issue and previewing the contents to verify they appear correctly. I also verified that the raw emojis could be sent through the GitHub API by adding issue comments programmatically to a different repo.